### PR TITLE
Add address and port to `apostrophe-site` options that are passed

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,8 @@ var site = require('apostrophe-site')({
   title: 'Apostrophe Boilerplate',
   sessionSecret: 'apostrophe sandbox demo party',
   adminPassword: 'demo',
+  address: '0.0.0.0',
+  port: 3000,
 
   // Force a2 to prefix all of its URLs. It still
   // listens on its own port, but you can configure


### PR DESCRIPTION
Reflects changes with updated apostrophe and appy to specify host
and address rather than configuring this in the data/host and
data/address file
