### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:6.5.0
+
+# Create app directory
+RUN mkdir -p /app
+WORKDIR /app
+
+# Bundle app source
+COPY . /app
+RUN npm install
+
+# Mount persistent storage
+VOLUME /app/data
+VOLUME /app/public/uploads
+
+EXPOSE 3000
+CMD [ "npm", "start" ]


### PR DESCRIPTION
See my [issue comment](https://github.com/punkave/apostrophe/issues/619#issuecomment-245484175) on #619 for more information.

If you're interested in making this easy for people using Docker, this is something I've used with Apostrophe and it works fine. It's dead simple: all it does is copies the project folder into the [node 6.5.0](https://hub.docker.com/_/node/) Docker image, then runs `npm run start` when the container starts. Since Apostrophe doesn't have any other requirements, this is all we need.

I've taken an unopinionated ([and best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run-only-one-process-per-container)) approach by not including MongoDB in this image. Docker users should know how to make their own separate Mongo container (using [the provided Mongo Docker image](https://hub.docker.com/_/mongo/)) and link it with this one.

This works with [a demo Candlewaster site](https://notabug.org/candlewaster/candlewaster-apostrophe) I've built.
