### PR TITLE
Ignore front-end JS in nodemonConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "nodemonConfig": {
     "verbose": true,
     "ignore": [
+      "lib/modules/*/public/js/*.js",
       "locales/*.json",
       "public/modules/**/*.less",
       "public/modules/**/*.js",


### PR DESCRIPTION
We don't need the whole server to restart when front-end JS changes (and we're already ignoring the symlinks to these files in `public/modules/**/*.js`)