### PR TITLE
Optional param to indicate project db

### DIFF
--- a/scripts/sync-down
+++ b/scripts/sync-down
@@ -15,7 +15,6 @@ source "deployment/settings.$TARGET" || exit 1
 if [ -z "$db" ]; then
   dbName=$PROJECT
 else
-  echo "hola"
   dbName=$DB
 fi
 

--- a/scripts/sync-down
+++ b/scripts/sync-down
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 TARGET="$1"
-DB="$2"
 if [ -z "$TARGET" ]; then
   echo "Usage: ./scripts/sync-down production [dbname]"
   echo "(or as appropriate)"
@@ -12,10 +11,10 @@ source deployment/settings || exit 1
 source "deployment/settings.$TARGET" || exit 1
 
 #Enter the Mongo DB name (should be same locally and remotely).
-if [ -z "$DB" ]; then
+if [ -z "$APOS_DATABASE_NAME" ]; then
   dbName=$PROJECT
 else
-  dbName=$DB
+  dbName=$APOS_DATABASE_NAME
 fi
 
 #Enter the Project name (should be what you called it for stagecoach).

--- a/scripts/sync-down
+++ b/scripts/sync-down
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TARGET="$1"
+DB="$2"
 if [ -z "$TARGET" ]; then
   echo "Usage: ./scripts/sync-down production"
   echo "(or as appropriate)"
@@ -11,7 +12,12 @@ source deployment/settings || exit 1
 source "deployment/settings.$TARGET" || exit 1
 
 #Enter the Mongo DB name (should be same locally and remotely).
-dbName=$PROJECT
+if [ -z "$db" ]; then
+  dbName=$PROJECT
+else
+  echo "hola"
+  dbName=$DB
+fi
 
 #Enter the Project name (should be what you called it for stagecoach).
 projectName=$PROJECT

--- a/scripts/sync-down
+++ b/scripts/sync-down
@@ -3,7 +3,7 @@
 TARGET="$1"
 DB="$2"
 if [ -z "$TARGET" ]; then
-  echo "Usage: ./scripts/sync-down production"
+  echo "Usage: ./scripts/sync-down production [dbname]"
   echo "(or as appropriate)"
   exit 1
 fi

--- a/scripts/sync-down
+++ b/scripts/sync-down
@@ -12,7 +12,7 @@ source deployment/settings || exit 1
 source "deployment/settings.$TARGET" || exit 1
 
 #Enter the Mongo DB name (should be same locally and remotely).
-if [ -z "$db" ]; then
+if [ -z "$DB" ]; then
   dbName=$PROJECT
 else
   dbName=$DB

--- a/scripts/sync-up
+++ b/scripts/sync-up
@@ -3,7 +3,7 @@
 TARGET="$1"
 DB="$2"
 if [ -z "$TARGET" ]; then
-  echo "Usage: ./scripts/sync-up production"
+  echo "Usage: ./scripts/sync-up production [dbname]"
   echo "(or as appropriate)"
   echo
   echo "THIS WILL CLOBBER EVERYTHING ON THE"
@@ -26,7 +26,6 @@ source "deployment/settings.$TARGET" || exit 1
 if [ -z "$db" ]; then
   dbName=$PROJECT
 else
-  echo "hola"
   dbName=$DB
 fi
 

--- a/scripts/sync-up
+++ b/scripts/sync-up
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 TARGET="$1"
-DB="$2"
 if [ -z "$TARGET" ]; then
   echo "Usage: ./scripts/sync-up production [dbname]"
   echo "(or as appropriate)"
@@ -23,10 +22,10 @@ source deployment/settings || exit 1
 source "deployment/settings.$TARGET" || exit 1
 
 #Enter the Mongo DB name (should be same locally and remotely).
-if [ -z "$DB" ]; then
+if [ -z "$APOS_DATABASE_NAME" ]; then
   dbName=$PROJECT
 else
-  dbName=$DB
+  dbName=$APOS_DATABASE_NAME
 fi
 
 #Enter the Project name (should be what you called it for stagecoach).

--- a/scripts/sync-up
+++ b/scripts/sync-up
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TARGET="$1"
+DB="$2"
 if [ -z "$TARGET" ]; then
   echo "Usage: ./scripts/sync-up production"
   echo "(or as appropriate)"
@@ -22,7 +23,12 @@ source deployment/settings || exit 1
 source "deployment/settings.$TARGET" || exit 1
 
 #Enter the Mongo DB name (should be same locally and remotely).
-dbName=$PROJECT
+if [ -z "$db" ]; then
+  dbName=$PROJECT
+else
+  echo "hola"
+  dbName=$DB
+fi
 
 #Enter the Project name (should be what you called it for stagecoach).
 projectName=$PROJECT

--- a/scripts/sync-up
+++ b/scripts/sync-up
@@ -23,7 +23,7 @@ source deployment/settings || exit 1
 source "deployment/settings.$TARGET" || exit 1
 
 #Enter the Mongo DB name (should be same locally and remotely).
-if [ -z "$db" ]; then
+if [ -z "$DB" ]; then
   dbName=$PROJECT
 else
   dbName=$DB


### PR DESCRIPTION
Hi! In several projects that we have started with the name of the project different from the name of the database, we have had a problem doing a sync-down or sync-up, since they are made so that the database has the same name as the project.

I thought it would be nice to have an optional parameter that is the name of the database, and thus be able to use these scripts in the case there is this problem.