### PR TITLE
Adds robots.txt file that disallows the modules directory

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /modules/


### PR DESCRIPTION
This has become standard practice for us. Also related to this issue in the core repo: https://github.com/apostrophecms/apostrophe/issues/1324.